### PR TITLE
FinOps bot suggestions

### DIFF
--- a/vm-and-sql.bicep
+++ b/vm-and-sql.bicep
@@ -2,7 +2,7 @@ param sqlServerName string = 'mySqlServer'
 param adminUsername string = 'adminUser'
 param adminPassword securestring = secure('adminPassword')
 param vmName string = 'myVM'
-param vmSize string = 'Standard_DS2_v2'
+param vmSize string = 'Standard_D4_v5'
 
 var sqlDatabaseName = 'myDatabase'
 var sqlUsername = 'myUsername'
@@ -17,6 +17,12 @@ resource sqlServer 'Microsoft.Sql/servers@2020-02-02-preview' = {
   properties: {
     administratorLogin: sqlUsername
     administratorLoginPassword: sqlPassword
+    sku: {
+      name: 'GP_S_Gen5_2'
+      tier: 'GeneralPurpose'
+      capacity: 2
+      family: 'Gen5'
+    }
   }
 }
 
@@ -65,6 +71,10 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-03-01' = {
           id: nic.id
         }
       ]
+    }
+    autoShutdownProfile: {
+      enabled: true
+      stopVMGracePeriod: 'PT2H' // Adjust the desired grace period as needed
     }
   }
 }


### PR DESCRIPTION
Based on the given cost-saving guidelines, here's a review of the provided code:

1. VM SKU Standard_DS2_v2:
   The code specifies the VM size as "Standard_DS2_v2," which is not one of the recommended SKUs (Standard_D4_v5 or Standard_D16_v5) for cost-saving. It's advisable to modify the code to use one of the recommended SKUs.

2. SQL Server and Database:
   The code correctly sets the tags for the SQL Server and database to indicate a non-production environment. However, it doesn't use the recommended 'serverless' SKU for non-production SQL servers. To align with the cost-saving guidelines, consider changing the SKU to the serverless option.

3. Auto-shutdown for non-production VMs:
   The code doesn't include any auto-shutdown configuration for the virtual machine. To align with the cost-saving guidelines, you should add the necessary configuration to enable auto-shutdown for non-production VMs.

Overall, the provided code doesn't fully comply with the cost-saving guidelines. I would suggest making the following changes:

- Update the VM SKU to either 'Standard_D4_v5' or 'Standard_D16_v5' as per the cost-saving guidelines.
- Modify the SQL Server resource to use the 'serverless' SKU for non-production environments.
- Add auto-shutdown configuration for the virtual machine to align with the cost-saving guidelines.

By implementing these changes, you can ensure that the code follows the recommended cost-saving practices for Azure deployments.